### PR TITLE
Spec logging

### DIFF
--- a/spec/synchrony_spec.rb
+++ b/spec/synchrony_spec.rb
@@ -45,9 +45,7 @@ describe 'A mock app' do
   it 'logs' do
     mock_app {
       enable :logging
-      get '/' do
-        'ok'
-      end
+      get('/') {}
     }
     get '/'
     deny { last_response.errors.empty? }

--- a/spec/synchrony_spec.rb
+++ b/spec/synchrony_spec.rb
@@ -41,4 +41,15 @@ describe 'A mock app' do
     expect { last_response.ok? }
     expect { last_response.headers['Set-Cookie'] }
   end
+
+  it 'logs' do
+    mock_app {
+      enable :logging
+      get '/' do
+        'ok'
+      end
+    }
+    get '/'
+    deny { last_response.errors.empty? }
+  end
 end


### PR DESCRIPTION
This specs the logging story. It still passes when async-rack is commented out, though. So back to square one I suppose.

Can you confirm the logging problem is still there without rack async?
