### PR TITLE
Don't be so strict with external API requirements.

### DIFF
--- a/sinatra-synchrony.gemspec
+++ b/sinatra-synchrony.gemspec
@@ -12,15 +12,15 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = s.name
   s.required_rubygems_version =         '>= 1.3.4'
-  s.add_dependency 'sinatra',           '>~ 1.0'
-  s.add_dependency 'rack-fiber_pool',   '>~ 0.9'
+  s.add_dependency 'sinatra',           '~> 1.0'
+  s.add_dependency 'rack-fiber_pool',   '~> 0.9'
   s.add_dependency 'eventmachine',      '> 1.0.0.beta.1', '< 1.0.0.beta.100'
-  s.add_dependency 'em-http-request',   '>~ 1.0'
-  s.add_dependency 'em-synchrony',      '>~ 1.0'
-  s.add_dependency 'em-resolv-replace', '>~ 1.1'
+  s.add_dependency 'em-http-request',   '~> 1.0'
+  s.add_dependency 'em-synchrony',      '~> 1.0'
+  s.add_dependency 'em-resolv-replace', '~> 1.1'
 
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rack-test', '>~ 0.5'
-  s.add_development_dependency 'wrong',     '>~ 0.5'
+  s.add_development_dependency 'rack-test', '~> 0.5'
+  s.add_development_dependency 'wrong',     '~> 0.5'
   s.add_development_dependency 'minitest'
 end


### PR DESCRIPTION
Sorry about the last one, must have been off focus I did >~ instead of ~>.  It shouldn't break any APIs for you since we just constrain it to bug fix versions but I guess I can see with the eventmachine because it is beta but if it breaks I use your script on a production site that gets quite a bit of traffic so I'll always back you up in fixing it fast :P.

Signed-off-by: Jordon Bedwell jordon@envygeeks.com
