### PR TITLE
Bump EventMachine and em-synchrony versions

### DIFF
--- a/sinatra-synchrony.gemspec
+++ b/sinatra-synchrony.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.required_rubygems_version =         '>= 1.3.4'
   s.add_dependency 'sinatra',           '~> 1.0'
   s.add_dependency 'rack-fiber_pool',   '~> 0.9'
-  s.add_dependency 'eventmachine',      '> 1.0.0.beta.1', '< 1.0.0.beta.100'
+  s.add_dependency 'eventmachine',      '~> 1.0.0.beta.4', '< 1.0.0.beta.100'
   s.add_dependency 'em-http-request',   '~> 1.0'
-  s.add_dependency 'em-synchrony',      '~> 1.0'
+  s.add_dependency 'em-synchrony',      '~> 1.0.1'
   s.add_dependency 'em-resolv-replace', '~> 1.1'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
There was a problem in the ConnectionPool class where it calls `send` rather than `__send__`. This makes its very difficult to use a `TCPSocket` directly (since it defines it's own `send`)

Additionally, version 1.0.0 of em-synchrony lacks the "Fiber-aware EM.next_tick convenience function".

Bumping this gem to use 1.0.1 will clear that all up.
