### PR TITLE
Fix output of show_exception

### DIFF
--- a/lib/sinatra/synchrony.rb
+++ b/lib/sinatra/synchrony.rb
@@ -24,7 +24,7 @@ module Sinatra
           s, h, b = printer.call(env)
           [s, h, b]
         else
-          [500, {}, ""]
+          [500, {}, [""]]
         end
       end
     end


### PR DESCRIPTION
The body part of the response must respond to each, and yield strings.
see "The Body" in: http://rack.rubyforge.org/doc/files/SPEC.html.

Currently, the following unhandled exception will trigger in ruby 1.9.2 if show_exceptions is false, and some rack middleware raises an exception:

```
E, [2012-10-09T17:01:37.019029 #60242] ERROR -- : undefined method `each' for "":String (NoMethodError)
/opt/ooyala/rubies/1.9.2-p290/lib/ruby/gems/1.9.1/gems/rainbows-4.3.1/lib/rainbows/response.rb:67:in `write_body_each'
/opt/ooyala/rubies/1.9.2-p290/lib/ruby/gems/1.9.1/gems/rainbows-4.3.1/lib/rainbows/response.rb:74:in `write_response'
/opt/ooyala/rubies/1.9.2-p290/lib/ruby/gems/1.9.1/gems/rainbows-4.3.1/lib/rainbows/response.rb:189:in `write_response'
/opt/ooyala/rubies/1.9.2-p290/lib/ruby/gems/1.9.1/gems/rainbows-4.3.1/lib/rainbows/event_machine/client.rb:87:in `ev_write_response'
/opt/ooyala/rubies/1.9.2-p290/lib/ruby/gems/1.9.1/gems/rainbows-4.3.1/lib/rainbows/ev_core.rb:30:in `write_async_response'
/opt/ooyala/rubies/1.9.2-p290/lib/ruby/gems/1.9.1/gems/rack-fiber_pool-0.9.2/lib/rack/fiber_pool.rb:24:in `call'
/opt/ooyala/rubies/1.9.2-p290/lib/ruby/gems/1.9.1/gems/rack-fiber_pool-0.9.2/lib/rack/fiber_pool.rb:24:in `rescue in block in call'
/opt/ooyala/rubies/1.9.2-p290/lib/ruby/gems/1.9.1/gems/rack-fiber_pool-0.9.2/lib/rack/fiber_pool.rb:20:in `block in call'
/opt/ooyala/rubies/1.9.2-p290/lib/ruby/gems/1.9.1/gems/rack-fiber_pool-0.9.2/lib/fiber_pool.rb:48:in `call'
/opt/ooyala/rubies/1.9.2-p290/lib/ruby/gems/1.9.1/gems/rack-fiber_pool-0.9.2/lib/fiber_pool.rb:48:in `block (3 levels) in initialize'
/opt/ooyala/rubies/1.9.2-p290/lib/ruby/gems/1.9.1/gems/rack-fiber_pool-0.9.2/lib/fiber_pool.rb:47:in `loop'
/opt/ooyala/rubies/1.9.2-p290/lib/ruby/gems/1.9.1/gems/rack-fiber_pool-0.9.2/lib/fiber_pool.rb:47:in `block (2 levels) in initialize'
```
